### PR TITLE
Detect ESM module and output import instead of require

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ examples/index.*.js
 
 # Ignore tarballs created when testing
 *.tgz
+
+
+.devcontainer
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-reflection",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "description": "Type reflection utilities for TypeScript.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/transformer/utils/codeGenerators.ts
+++ b/src/transformer/utils/codeGenerators.ts
@@ -3,11 +3,37 @@ import ts from 'typescript';
 export const createVariable = (identifier: ts.Identifier, initializer: ts.Expression): ts.Statement =>
   ts.createVariableStatement(undefined, [ts.createVariableDeclaration(identifier, undefined, initializer)]);
 
-export const createRequire = (identifier: ts.Identifier, path: string, property = 'default'): ts.Statement =>
+export const createImportStatement = (namedImport: string, path: string): ts.Statement => {
+  // from https://stackoverflow.com/questions/59693819/generate-import-statement-programmatically-using-typescript-compiler-api
+
+  return ts.createImportDeclaration(
+    /* decorators */ undefined,
+    /* modifiers */ undefined,
+    ts.createImportClause(
+      undefined,
+      ts.createNamedImports([ts.createImportSpecifier(undefined, ts.createIdentifier(namedImport))]),
+    ),
+    ts.createLiteral(path),
+  );
+};
+
+export const createRequire = (identifier: ts.Identifier, path: string, property = 'default'): ts.Statement[] => [
   createVariable(
     identifier,
     ts.createPropertyAccess(
       ts.createCall(ts.createIdentifier('require'), undefined, [ts.createLiteral(path)]),
       property,
     ),
-  );
+  ),
+];
+
+export const createImport = (identifier: ts.Identifier, path: string, property = 'default'): ts.Statement[] => [
+  createImportStatement(property, path),
+  ts.createVariableStatement(
+    undefined,
+    ts.createVariableDeclarationList(
+      [ts.createVariableDeclaration(identifier, undefined, ts.createIdentifier(property))],
+      ts.NodeFlags.None,
+    ),
+  ),
+];


### PR DESCRIPTION
This PR adds support for TS projects where the modules target is es2015 or higher.  When ts-reflection runs, it will use the appropriate import statement in the output rather than CommonJS require().  CommonJS module support remains intact.